### PR TITLE
Fix a buggy Hook

### DIFF
--- a/src/hooks/useKeydown.js
+++ b/src/hooks/useKeydown.js
@@ -16,6 +16,5 @@ export default function useKeydown(key, callback) {
     return () => {
       window.removeEventListener('keydown', handler)
     }
-  // eslint-disable-next-line
-  }, [])
+  }, [key, callback])
 }


### PR DESCRIPTION
This is wrong and will lead to a bug. The rule knows what it's doing.

In particular, if the `callback` you pass uses some prop or state, it will forever capture the initial value. It will not be updated.

Just let the browser resubscribe. It is almost free. And in the worst case you can always memoize the callback itself before passing it.